### PR TITLE
Fixes links in admin/structure/biblio/%/fields

### DIFF
--- a/modules/biblio_ui/biblio_ui.module
+++ b/modules/biblio_ui/biblio_ui.module
@@ -315,7 +315,6 @@ function biblio_ui_entity_info_alter(&$info) {
       'label' => $bundle->name,
       'admin' => array(
         'path' => 'admin/structure/biblio/' . $bundle->type,
-        'real path' => 'admin/structure/biblio/' . str_replace('_', '-', $bundle->type),
         'access arguments' => array('manage biblio structure'),
       ),
     );


### PR DESCRIPTION
Currently links in the manage fields page is broken for bundles with spaces/_ in the names.
