### PR TITLE
Fixed: Missing "Edit" button in contributors.

### DIFF
--- a/biblio.module
+++ b/biblio.module
@@ -427,7 +427,7 @@ function biblio_entity_access($op, $type = NULL, $account = NULL) {
       return user_access('administer biblio', $account)
           || user_access('access biblio content', $account);
     case 'delete':
-    case 'edit':
+    case 'update':
       return user_access('administer biblio')
           || user_access('edit all biblio entries');
   }


### PR DESCRIPTION
Changed biblio access op from 'edit' to 'update'. The "Edit" button now appears next to the "Remove" button.

Before:
![updateedit_before](https://f.cloud.github.com/assets/3273122/1473522/4393ebd2-461c-11e3-99f7-2646f9b8b9e1.png)

After:
![updateedit_after](https://f.cloud.github.com/assets/3273122/1473523/465a7f0c-461c-11e3-8baa-e743041a1219.png)
