### PR TITLE
Add export for one Biblio entity.

### DIFF
--- a/includes/biblio.controller.inc
+++ b/includes/biblio.controller.inc
@@ -23,6 +23,7 @@ class Biblio extends Entity {
     }
     return entity_get_controller($this->entityType)->buildContent($this, $view_mode, $langcode, $content);
   }
+  
   /**
    * Override Entity:save().
    *

--- a/includes/biblio.controller.inc
+++ b/includes/biblio.controller.inc
@@ -9,6 +9,20 @@ class Biblio extends Entity {
     parent::__construct($values, 'biblio');
   }
 
+  public function buildContent($view_mode = 'full', $langcode = NULL, $content = array()) {
+    // Add the export if it is visible.
+    $fields = field_extra_fields_get_display('biblio', $this->type, $view_mode);
+    if (isset($fields['export']) && $fields['export']['visible']) {
+      $variables = array();
+      $variables['bid'] = $this->bid;
+
+      $content['export'] = array(
+        '#markup' => theme('biblio_ui_entity_export_area', $variables),
+        '#weight' => $fields['export']['weight'],
+      );
+    }
+    return entity_get_controller($this->entityType)->buildContent($this, $view_mode, $langcode, $content);
+  }
   /**
    * Override Entity:save().
    *

--- a/includes/biblio.controller.inc
+++ b/includes/biblio.controller.inc
@@ -21,9 +21,12 @@ class Biblio extends Entity {
         '#weight' => $fields['export']['weight'],
       );
     }
+
+    // Calling parent::buildContent() won't work, since we need to send the
+    // content as well.
     return entity_get_controller($this->entityType)->buildContent($this, $view_mode, $langcode, $content);
   }
-  
+
   /**
    * Override Entity:save().
    *

--- a/modules/biblio_ui/biblio_ui.module
+++ b/modules/biblio_ui/biblio_ui.module
@@ -418,7 +418,18 @@ function theme_biblio_ui_add_biblio_list($variables) {
 /**
  * Viewing a biblio entity entry.
  */
-function biblio_ui_view_biblio($biblio, $view_mode = 'full') {
+function biblio_ui_view_biblio($biblio, $view_mode = 'full', $langcode = NULL) {
+
+  // Remove previously built content, if exists.
+  $biblio->content = array();
+
+  // Allow modules to change the view mode.
+  $context = array(
+    'entity_type' => 'biblio',
+    'entity' => $biblio,
+    'langcode' => $langcode,
+  );
+  drupal_alter('entity_view_mode', $view_mode, $context);
 
   // Add the export if it is visible.
   $fields = field_extra_fields_get_display('biblio', $biblio->type, $view_mode);
@@ -426,17 +437,46 @@ function biblio_ui_view_biblio($biblio, $view_mode = 'full') {
     $variables = array();
     $variables['bid'] = $biblio->bid;
 
-    $biblio->export = array(
+    $biblio->content['export'] = array(
       '#markup' => theme('biblio_ui_entity_export_area', $variables),
       '#weight' => $fields['export']['weight'],
     );
   }
 
+  // Build fields content.
+  // In case of a multiple view, taxonomy_term_view_multiple() already ran the
+  // 'prepare_view' step. An internal flag prevents the operation from running
+  // twice.
+  field_attach_prepare_view('biblio', array($biblio->bid => $biblio), $view_mode, $langcode);
+  entity_prepare_view('biblio', array($biblio->bid => $biblio), $langcode);
+  $biblio->content += field_attach_view('biblio', $biblio, $view_mode, $langcode);
+
+  // Allow modules to make their own additions to the taxonomy term.
+  module_invoke_all('biblio_view', $biblio, $view_mode, $langcode);
+  module_invoke_all('entity_view', $biblio, 'biblio', $view_mode, $langcode);
+
+  // Make sure the current view mode is stored if no module has already
+  // populated the related key.
+  $biblio->content += array('#view_mode' => $view_mode);
+/*
   $wrapper = entity_metadata_wrapper('biblio', $biblio);
   $info = $wrapper->view();
   $content = $info['biblio'][$wrapper->getIdentifier()];
+*/
+  $build = $biblio->content;
 
-  return render($content);
+  // We don't need duplicate rendering info in $term->content.
+  unset($biblio->content);
+  $build += array(
+    '#theme' => 'biblio',
+    '#biblio' => $biblio,
+    '#view_mode' => $view_mode,
+    '#language' => $langcode,
+  );
+  $type = 'biblio';
+  drupal_alter(array('biblio_view', 'entity_view'), $build, $type);
+  return $build;
+//  return render($content);
 }
 
 /**

--- a/modules/biblio_ui/biblio_ui.module
+++ b/modules/biblio_ui/biblio_ui.module
@@ -418,65 +418,12 @@ function theme_biblio_ui_add_biblio_list($variables) {
 /**
  * Viewing a biblio entity entry.
  */
-function biblio_ui_view_biblio($biblio, $view_mode = 'full', $langcode = NULL) {
-
-  // Remove previously built content, if exists.
-  $biblio->content = array();
-
-  // Allow modules to change the view mode.
-  $context = array(
-    'entity_type' => 'biblio',
-    'entity' => $biblio,
-    'langcode' => $langcode,
-  );
-  drupal_alter('entity_view_mode', $view_mode, $context);
-
-  // Add the export if it is visible.
-  $fields = field_extra_fields_get_display('biblio', $biblio->type, $view_mode);
-  if (isset($fields['export']) && $fields['export']['visible']) {
-    $variables = array();
-    $variables['bid'] = $biblio->bid;
-
-    $biblio->content['export'] = array(
-      '#markup' => theme('biblio_ui_entity_export_area', $variables),
-      '#weight' => $fields['export']['weight'],
-    );
-  }
-
-  // Build fields content.
-  // In case of a multiple view, taxonomy_term_view_multiple() already ran the
-  // 'prepare_view' step. An internal flag prevents the operation from running
-  // twice.
-  field_attach_prepare_view('biblio', array($biblio->bid => $biblio), $view_mode, $langcode);
-  entity_prepare_view('biblio', array($biblio->bid => $biblio), $langcode);
-  $biblio->content += field_attach_view('biblio', $biblio, $view_mode, $langcode);
-
-  // Allow modules to make their own additions to the taxonomy term.
-  module_invoke_all('biblio_view', $biblio, $view_mode, $langcode);
-  module_invoke_all('entity_view', $biblio, 'biblio', $view_mode, $langcode);
-
-  // Make sure the current view mode is stored if no module has already
-  // populated the related key.
-  $biblio->content += array('#view_mode' => $view_mode);
-/*
+function biblio_ui_view_biblio($biblio) {
   $wrapper = entity_metadata_wrapper('biblio', $biblio);
   $info = $wrapper->view();
   $content = $info['biblio'][$wrapper->getIdentifier()];
-*/
-  $build = $biblio->content;
 
-  // We don't need duplicate rendering info in $term->content.
-  unset($biblio->content);
-  $build += array(
-    '#theme' => 'biblio',
-    '#biblio' => $biblio,
-    '#view_mode' => $view_mode,
-    '#language' => $langcode,
-  );
-  $type = 'biblio';
-  drupal_alter(array('biblio_view', 'entity_view'), $build, $type);
-  return $build;
-//  return render($content);
+  return render($content);
 }
 
 /**

--- a/modules/biblio_ui/biblio_ui.module
+++ b/modules/biblio_ui/biblio_ui.module
@@ -67,6 +67,16 @@ function biblio_ui_menu() {
     'weight' => '70',
   );
 
+  $items['biblio/export/%/%'] = array(
+    'title' => t('Export Biblio'),
+    'description callback' => 'biblio_ui_description_callback',
+    'description arguments' => array(1, 'export'),
+    'access callback' => 'biblio_ui_export_access',
+    'access arguments' => array(2, 3),
+    'page callback' => 'biblio_ui_export_menu_item',
+    'page arguments' => array(2, 3),
+  );
+
   $items['biblio/export_view/%/%/%'] = array(
     'title' => t('Export Biblio by View'),
     'description callback' => 'biblio_ui_description_callback',
@@ -279,6 +289,7 @@ function biblio_ui_theme() {
     'biblio_ui_add_biblio_list' => array(),
     'biblio_ui_bundle_overview' => array(),
     'biblio_ui_view_export_area' => array(),
+    'biblio_ui_entity_export_area' => array(),
   );
 }
 
@@ -1033,6 +1044,35 @@ function biblio_ui_contributor_delete_form_submit($form, &$form_state) {
  * Menu access; Allow export based on existing Biblio style and user access.
  *
  * @param $style_name
+ *   Biblio style name.
+ * @param $bids_string
+ *   String of comma separated Biblio IDs.
+ *
+ * @return bool
+ */
+function biblio_ui_export_access($style_name, $bids_string) {
+  if (!user_access('view biblio')) {
+    // User can't view Biblios.
+    return;
+  }
+
+  if (!biblio_get_exportable_biblio_style($style_name)) {
+    // Style name doesn't exist.
+    return;
+  }
+
+  if (!biblio_ui_get_ids_from_string($bids_string)) {
+    // No Biblios found on string.
+    return;
+  }
+  return TRUE;
+}
+
+
+/**
+ * Menu access; Allow export based on existing Biblio style and user access.
+ *
+ * @param $style_name
  *   Biblio style string.
  * @param $view_name
  *   Biblio related View name.
@@ -1081,6 +1121,19 @@ function biblio_ui_export($style_name, $bids = array()) {
 }
 
 /**
+ * Export a Biblio entity to a file by a given format.
+ *
+ * @param $style_name
+ *   Biblio style string.
+ * @param $bids_string
+ *   Comma-separated list of Biblio IDs.
+ */
+function biblio_ui_export_menu_item($style_name, $bids_string = '') {
+  $bids = biblio_ui_get_ids_from_string($bids_string);
+  biblio_ui_export($style_name, $bids);
+}
+
+/**
  * Export a Biblio entities to a file by a View.
  *
  * @param $style_name
@@ -1107,6 +1160,30 @@ function biblio_ui_export_view($style_name, $view_name, $display_name) {
     $bids[] = $biblio->bid;
   }
   biblio_ui_export($style_name, $bids);
+}
+
+/**
+ * Get IDs from string of comma separated numbers.
+ *
+ * @param $bids_string
+ *   Comma-separated list of Biblio IDs.
+ *
+ * @return array|bool
+ *   Array of Biblio IDs, or FALSE if none found.
+ */
+function biblio_ui_get_ids_from_string($bids_string = '') {
+  if (!$bids = explode(',', $bids_string)) {
+    return;
+  }
+
+  // Verify each item is a number.
+  foreach ($bids as $bid) {
+    if (!is_numeric($bid)) {
+      return;
+    }
+  }
+
+  return $bids;
 }
 
 /**
@@ -1157,4 +1234,50 @@ function theme_biblio_ui_view_export_area($variables) {
     'attributes' => array('class' => array('biblio-export-buttons')),
   );
   return theme('ctools_dropdown', $attributes);
+}
+
+/**
+ * Theme callback - display a button for export in Biblio entity.
+ */
+function theme_biblio_ui_entity_export_area($variables) {
+  $title = t('Export');
+  $links = array();
+  foreach (biblio_get_exportable_biblio_styles() as $style_name => $style) {
+    $links[$style_name] = array(
+      'href' => 'biblio/export/' . $style_name . '/' . $variables['bid'],
+      'title' => $style['title'],
+      'attributes' => array(
+        'title' => t('Click to download Biblio in @format format', array('@format' => $style_name)),
+      ),
+    );
+  }
+
+  $attributes = array(
+    'links' => $links,
+    'title' => $title,
+    'attributes' => array('class' => array('biblio-export-buttons')),
+  );
+  return theme('ctools_dropdown', $attributes);
+}
+
+/**
+ * Implementing hook_entity_view_alter().
+ * Used to add the Biblio export to the full view of a Biblio entity.
+ *
+ * @param $build
+ * @param $type
+ */
+function biblio_ui_biblio_view_alter(&$build, $type) {
+  if ($build['#view_mode'] != 'full') {
+    return;
+  }
+  $biblio = $build['#entity'];
+
+  $variables = array();
+  $variables['bid'] = $biblio->bid;
+
+  $build['export_form'] = array(
+    '#weight' => -10,
+    '#markup' => theme('biblio_ui_entity_export_area', $variables),
+  );
 }

--- a/modules/biblio_ui/biblio_ui.module
+++ b/modules/biblio_ui/biblio_ui.module
@@ -1223,7 +1223,7 @@ function theme_biblio_ui_view_export_area($variables) {
       'href' => 'biblio/export_view/' . $style_name . '/' . $variables['view_name'] . '/' . $variables['display_name'],
       'title' => $style['title'],
       'attributes' => array(
-        'title' => t('Click to download Biblio in @format format', array('@format' => $style_name)),
+        'title' => t('Click to Download Biblio in @format format', array('@format' => $style_name)),
       ),
     );
   }
@@ -1247,7 +1247,7 @@ function theme_biblio_ui_entity_export_area($variables) {
       'href' => 'biblio/export/' . $style_name . '/' . $variables['bid'],
       'title' => $style['title'],
       'attributes' => array(
-        'title' => t('Click to download Biblio in @format format', array('@format' => $style_name)),
+        'title' => t('Click to Download Biblio in @format format', array('@format' => $style_name)),
       ),
     );
   }

--- a/modules/biblio_ui/biblio_ui.module
+++ b/modules/biblio_ui/biblio_ui.module
@@ -418,7 +418,20 @@ function theme_biblio_ui_add_biblio_list($variables) {
 /**
  * Viewing a biblio entity entry.
  */
-function biblio_ui_view_biblio($biblio) {
+function biblio_ui_view_biblio($biblio, $view_mode = 'full') {
+
+  // Add the export if it is visible.
+  $fields = field_extra_fields_get_display('biblio', $biblio->type, $view_mode);
+  if (isset($fields['export']) && $fields['export']['visible']) {
+    $variables = array();
+    $variables['bid'] = $biblio->bid;
+
+    $biblio->export = array(
+      '#markup' => theme('biblio_ui_entity_export_area', $variables),
+      '#weight' => $fields['export']['weight'],
+    );
+  }
+
   $wrapper = entity_metadata_wrapper('biblio', $biblio);
   $info = $wrapper->view();
   $content = $info['biblio'][$wrapper->getIdentifier()];
@@ -1261,23 +1274,22 @@ function theme_biblio_ui_entity_export_area($variables) {
 }
 
 /**
- * Implementing hook_entity_view_alter().
- * Used to add the Biblio export to the full view of a Biblio entity.
- *
- * @param $build
- * @param $type
+ * Implementation of hook_field_extra_fields().
  */
-function biblio_ui_biblio_view_alter(&$build, $type) {
-  if ($build['#view_mode'] != 'full') {
-    return;
+function biblio_ui_field_extra_fields() {
+
+  $return = array();
+  $info = entity_get_info('biblio');
+  foreach (array_keys($info['bundles']) as $bundle) {
+    $return['biblio'][$bundle] = array(
+      'display' => array(
+        'export' => array(
+          'label' => t('Export links'),
+          'description' => t('Export Biblio to a file.'),
+          'weight' => -10,
+        ),
+      ),
+    );
   }
-  $biblio = $build['#entity'];
-
-  $variables = array();
-  $variables['bid'] = $biblio->bid;
-
-  $build['export_form'] = array(
-    '#weight' => -10,
-    '#markup' => theme('biblio_ui_entity_export_area', $variables),
-  );
+  return $return;
 }


### PR DESCRIPTION
#127

Adding export for one Biblio entity by adding an extra field using hook_field_extra_fields() and biblio.controller.inc buildContent().

![export3](https://f.cloud.github.com/assets/99186/1829476/d8837200-72c0-11e3-8668-506cee767b55.png)
![export4](https://f.cloud.github.com/assets/99186/1829477/dad92c66-72c0-11e3-922d-ba17e961e552.png)
![selection_011](https://f.cloud.github.com/assets/99186/1830197/d1f698a8-732a-11e3-9670-d044a9bb225d.png)
![selection_009](https://f.cloud.github.com/assets/99186/1830198/d4fd1d10-732a-11e3-8f31-47824379d0e3.png)
![selection_010](https://f.cloud.github.com/assets/99186/1830199/e5f6cd78-732a-11e3-9e8b-bfae7daaccef.png)
